### PR TITLE
Added Constant and GroupedConstants, added tests, example

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 terrier989 <terrier989@gmail.com>, EPNW <prokopwieler.hardundsoftware@gmail.com>.
+Copyright (c) 2020 terrier989 <terrier989@gmail.com>, EPNW <prokopwieler.hardundsoftware@gmail.com>, mannprerak2 <mannprerak2@gmail.com>.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/example/example.dart
+++ b/example/example.dart
@@ -26,5 +26,42 @@ final library = const Library.platformAware(
       name: 'ExampleGlobal',
       type: 'int32',
     ),
+
+    // A Struct
+    Struct(
+      name: 'ExampleStruct',
+      fields: [
+        StructField(
+          name: 'exampleInt',
+          type: 'int32'
+        ),
+      ]
+    ),
+
+    // A constant
+    Constant(
+      name: 'exampleConstant',
+      type: 'int',
+      value: '10',
+      documentation: 'A constant',
+    ),
+
+    // A group of constants
+    GroupedConstants(
+      name: 'ExampleConstantGroup',
+      documentation: 'Just an Example of using GroupedConstants',
+      constants: [
+        Constant(
+          name: 'exampleintConstant',
+          type: 'double',
+          value: '10.2',
+        ),
+        Constant(
+          name: 'exampleStringConstant',
+          type: 'String',
+          value: '"example string"',
+        ),
+      ],
+    ),
   ],
 );

--- a/lib/src/c/constant.dart
+++ b/lib/src/c/constant.dart
@@ -1,7 +1,7 @@
 // Copyright (c) 2020 ffi_tool authors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
+// of this software and associated documentation files (the 'Software'), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
@@ -10,7 +10,7 @@
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
 //
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
 // IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -18,15 +18,35 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
 // OR OTHER DEALINGS IN THE SOFTWARE.
 
-/// Generates 'dart:ffi' bindings for C libraries.
-library ffi_tool.c;
+import 'package:meta/meta.dart';
 
-export 'src/c/config.dart';
-export 'src/c/generate_file.dart';
-export 'src/c/library.dart';
-export 'src/c/func.dart' hide Parameter;
-export 'src/c/struct.dart';
-export 'src/c/global.dart';
-export 'src/c/dart_source_writer.dart' hide DartSourceWriter;
-export 'src/c/constant.dart';
-export 'src/c/grouped_constant.dart';
+import 'library.dart';
+import 'dart_source_writer.dart';
+
+/// A simple constant - `const int a = 10;`
+///
+/// This doesn't bind with any C variable
+///
+/// Expands to `const $type $name = $value;`
+class Constant extends Element {
+  final String type;
+  final String value;
+
+  const Constant(
+      {@required String name,
+      @required this.type,
+      @required this.value,
+      String documentation})
+      : super(name: name, documentation: documentation);
+
+  @override
+  void generateSource(DartSourceWriter w, Library library) {
+    w.write('\n');
+    if (documentation != null) {
+      w.write('/// ');
+      w.writeAll(documentation.split('\n'), '\n/// ');
+      w.write('\n');
+    }
+    w.write('const $type $name = $value;\n');
+  }
+}

--- a/lib/src/c/grouped_constant.dart
+++ b/lib/src/c/grouped_constant.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2020 ffi_tool authors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the 'Software'), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+// OR OTHER DEALINGS IN THE SOFTWARE.
+
+import 'package:ffi_tool/src/c/constant.dart';
+import 'package:meta/meta.dart';
+
+import 'library.dart';
+import 'dart_source_writer.dart';
+
+/// Group of constants (wrapped in a class)
+///
+/// Expands to (example)
+/// ```dart
+/// class SomeName {
+///   static const int a = 10;
+///   static const String b = "hello";
+/// }
+/// ```
+class GroupedConstants extends Element {
+  final List<Constant> constants;
+
+  const GroupedConstants(
+      {@required String name, @required this.constants, String documentation})
+      : super(name: name, documentation: documentation);
+
+  @override
+  void generateSource(DartSourceWriter w, Library library) {
+    w.write('\n');
+    if (documentation != null) {
+      w.write('/// ');
+      w.writeAll(documentation.split('\n'), '\n/// ');
+      w.write('\n');
+    }
+    w.write('class $name {\n');
+    for (var constant in constants) {
+      w.write('\n');
+      var depth = '  ';
+      if (constant.documentation != null) {
+        w.write(depth + '/// ');
+        w.writeAll(constant.documentation.split('\n'), '\n' + depth + '/// ');
+        w.write('\n');
+      }
+      w.write(
+          depth + 'static const ${constant.type} ${constant.name} = ${constant.value};\n');
+    }
+    w.write('}\n');
+  }
+}

--- a/test/c_test.dart
+++ b/test/c_test.dart
@@ -190,4 +190,85 @@ typedef _Example_C = ffi.Pointer Function();
 typedef _Example_Dart = ffi.Pointer Function();
 ''');
   });
+
+  test('Constants', () {
+    final library = Library(
+      dynamicLibraryPath: 'path/to/library',
+      importedUris: {},
+      elements: [
+        Constant(
+            name: 'a',
+            type: 'int',
+            value: '10',
+            documentation: 'test doc line 1\ntest doc line 2'),
+        Constant(
+          name: 'b',
+          type: 'String',
+          value: '"test string"',
+        ),
+      ],
+    );
+    expect(library.toString(), '''
+// AUTOMATICALLY GENERATED. DO NOT EDIT.
+
+import 'dart:ffi' as ffi;
+
+/// Dynamic library
+final ffi.DynamicLibrary _dynamicLibrary = ffi.DynamicLibrary.open(
+  'path/to/library',
+);
+
+/// test doc line 1
+/// test doc line 2
+const int a = 10;
+
+const String b = "test string";
+''');
+  });
+
+  test('GroupedConstants', () {
+    final library = Library(
+      dynamicLibraryPath: 'path/to/library',
+      importedUris: {},
+      elements: [
+        GroupedConstants(
+          name: 'Constants',
+          documentation: 'test line 1\ntest line 2',
+          constants: [
+            Constant(
+                name: 'a',
+                type: 'int',
+                value: '10',
+                documentation: 'test doc line 1\ntest doc line 2'),
+            Constant(
+              name: 'b',
+              type: 'String',
+              value: '"test string"',
+            ),
+          ],
+        ),
+      ],
+    );
+    expect(library.toString(), '''
+// AUTOMATICALLY GENERATED. DO NOT EDIT.
+
+import 'dart:ffi' as ffi;
+
+/// Dynamic library
+final ffi.DynamicLibrary _dynamicLibrary = ffi.DynamicLibrary.open(
+  'path/to/library',
+);
+
+/// test line 1
+/// test line 2
+class Constants {
+
+  /// test doc line 1
+  /// test doc line 2
+  static const int a = 10;
+
+  static const String b = "test string";
+}
+''');
+  });
 }


### PR DESCRIPTION
Please suggest any changes if required. (closes #17) 
The example is also updated

Here's the example's output
```dart
// AUTOMATICALLY GENERATED. DO NOT EDIT.

import 'dart:ffi' as ffi;
import 'dart:io' as io show Platform;
import 'package:ffi/ffi.dart' as ffi;

/// Dynamic library
final ffi.DynamicLibrary _dynamicLibrary = _open();
ffi.DynamicLibrary _open() {
  if (io.Platform.isWindows)
    return ffi.DynamicLibrary.open('path/to/library.dll');
  if (io.Platform.isAndroid)
    return ffi.DynamicLibrary.open('path/to/library.so');
  if (io.Platform.isIOS) return ffi.DynamicLibrary.process();
  throw UnsupportedError('This platform is not supported.');
}

/// Takes parameters and does stuff.
void Example(
  int arg0,
  double arg1,
  ffi.Pointer arg2,
) {
  _Example(arg0, arg1, arg2);
}

final _Example_Dart _Example =
    _dynamicLibrary.lookupFunction<_Example_C, _Example_Dart>(
  'Example',
);
typedef _Example_C = ffi.Void Function(
  ffi.Int32 arg0,
  ffi.Double arg1,
  ffi.Pointer arg2,
);
typedef _Example_Dart = void Function(
  int arg0,
  double arg1,
  ffi.Pointer arg2,
);

/// C global `ExampleGlobal`.
final int ExampleGlobal = _dynamicLibrary
    .lookup<ffi.Int32>(
      'ExampleGlobal',
    )
    .value;

/// C struct `ExampleStruct`.
class ExampleStruct extends ffi.Struct {
  @ffi.Int32()
  int exampleInt;

  static ffi.Pointer<ExampleStruct> allocate() {
    return ffi.allocate<ExampleStruct>();
  }
}

/// A constant
const int exampleConstant = 10;

/// Just an Example of using GroupedConstants
class ExampleConstantGroup {
  static const double exampleintConstant = 10.2;

  static const String exampleStringConstant = "example string";
}

``` 