### PR TITLE
Remove annotation for Pointer type variables within Structs

### DIFF
--- a/lib/src/c/struct.dart
+++ b/lib/src/c/struct.dart
@@ -97,7 +97,7 @@ class Struct extends Element {
     for (var field in fields) {
       // Some types (Int32, Float32, etc.) need to be annotated
       final annotationName = w.getPropertyAnnotationType(field.type);
-      if (annotationName != null) {
+      if (annotationName != null && annotationName != 'ffi.Pointer') {
         w.write('  @$annotationName()\n');
       }
       w.write('  ${w.getDartType(field.type)} ${field.name};\n');


### PR DESCRIPTION
Added condition to filter out pointer types when adding annotation.  

Otherwise this was generating errant code with the following message:

> Fields in a struct class whose type is 'Pointer' should not have any annotations.
> Try removing the annotation.dart(annotation_on_pointer_field)